### PR TITLE
adding configuration for maven enforcer plugin, restrict JDK version to ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,10 @@
 					<version>2.3</version>
 				</plugin>
 				<plugin>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>1.2</version>
+				</plugin>
+				<plugin>
 					<artifactId>maven-install-plugin</artifactId>
 					<version>2.2</version>
 				</plugin>
@@ -209,6 +213,24 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.7,)</version>
+                </requireJavaVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
...1.7 or later

Fix for https://github.com/basespace/basespace-java-sdk/issues/2
